### PR TITLE
fix: Extend transaction time for POST/exercise (#42)

### DIFF
--- a/apps/web/app/api/exercise/route.ts
+++ b/apps/web/app/api/exercise/route.ts
@@ -41,6 +41,8 @@ export const POST = async (request: NextRequest) => {
         createdCount: updatedDiff.length,
         content: updatedDiff
       }
+    }, {
+      timeout: 20000,
     })
     return NextResponse.json(createdList);
   } catch (err) {


### PR DESCRIPTION
Due to temporarily using the Neon free plan as the production environment, the query performance is poor, which causes timeouts, so the transaction time has been extended.