### PR TITLE
Stop using `pnpm dlx` to run Prisma CLI to avoid version mismatch

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -53,6 +53,7 @@
 		"@types/react": "19.0.8",
 		"@types/react-dom": "19.0.3",
 		"postcss": "^8.5.1",
+		"prisma": "^5.22.0",
 		"tailwindcss": "^3.4.17",
 		"typescript": "^5.7.3"
 	}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,11 +5,11 @@
 	"main": "src/index.ts",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",
-		"migrate": "pnpm dlx prisma migrate dev --name init",
-		"migrate-deploy": "pnpm dlx prisma migrate deploy",
-		"generate": "pnpm dlx prisma generate",
+		"migrate": "pnpm prisma migrate dev --name init",
+		"migrate-deploy": "pnpm prisma migrate deploy",
+		"generate": "pnpm prisma generate",
 		"seed": "ts-node prisma/seed.ts",
-		"reset": "pnpm dlx prisma migrate reset"
+		"reset": "pnpm prisma migrate reset"
 	},
 	"keywords": [],
 	"author": "",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       postcss:
         specifier: ^8.5.1
         version: 8.5.3
+      prisma:
+        specifier: ^5.22.0
+        version: 5.22.0
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.17(ts-node@10.9.2(@types/node@22.14.1)(typescript@5.8.3))


### PR DESCRIPTION
This is related to https://github.com/oz841119/peasy-fit3/pull/70